### PR TITLE
Use `--markdown-headings=atx` option in pandoc call

### DIFF
--- a/rst2ipynb
+++ b/rst2ipynb
@@ -61,7 +61,7 @@ if args.verbose:
 p = Popen([
         'pandoc',
         '--filter', 'rst2ipynb-sageblock-filter',
-        '--atx-headers',
+        '--markdown-headings=atx',
         '--from', 'rst',
         '--to', 'markdown_github+tex_math_dollars+fenced_code_attributes',
     ], stdout=PIPE, stdin=PIPE)


### PR DESCRIPTION
The `--atx-headers` option is [deprecated since pandoc 2.11.2](https://pandoc.org/releases.html#pandoc-2.11.2-2020-11-19) (2020-11-19) and was [removed in pandoc 3.0](https://pandoc.org/releases.html#pandoc-3.0-2023-01-18) (2023-01-18).

This small change makes the instructions in https://ask.sagemath.org/question/40136/file-with-extension-sws/ work using Sage 10.0 on Ubuntu 22.04.